### PR TITLE
Revert "Use `.zshrc` instead of `.zprofile`"

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -903,7 +903,7 @@ class Installer:
 
         if "zsh" in SHELL:
             zdotdir = os.getenv("ZDOTDIR", HOME)
-            profiles.append(os.path.join(zdotdir, ".zshrc"))
+            profiles.append(os.path.join(zdotdir, ".zprofile"))
 
         bash_profile = os.path.join(HOME, ".bash_profile")
         if os.path.exists(bash_profile):


### PR DESCRIPTION
This reverts commit cc195f1dd086d1c4d12a3acc8d6766981ba431ac.


# Pull Request Check List

Resolves: #3850

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->